### PR TITLE
fix typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Please find vignettes for more information.
 
 ## Related work
 
-From version 3.0, **GWmodel** is based on a pure C++ library --- [libgwmodel](https://github.com/GWmodel-Lab/libgwmdoel).
+From version 3.0, **GWmodel** is based on a pure C++ library --- [libgwmodel](https://github.com/GWmodel-Lab/libgwmodel).
 This library implements all models, and **GWmodel** just calls this package by translating inputs and outputs.
 Besides, **GWmodel** also provides some handy functions for the convenience of R users.
 


### PR DESCRIPTION
real excited about the libgwmodel package. this is exactly the right way to go I think. so, it looks like the link to it from your readme is broken... 