### PR TITLE
Feature: specific MGWR configuration by name

### DIFF
--- a/R/gwr_multiscale.R
+++ b/R/gwr_multiscale.R
@@ -4,8 +4,7 @@
 #' @param data A `sf` objects.
 #' @param config Parameter-specified weighting configuration.
 #'  It must be a list of `MGWRConfig` objects.
-#'  Its length can be 1 or equal to the number of independent variables.
-#'  When its length is 1, elements will be duplicated for independent variable.
+#'  Please find more details in the details section.
 #' @param criterion Convergence criterion of back-fitting algorithm.
 #' @param optim_bw_range Bounds on bandwidth optimization, a vector of two numeric elements.
 #'  Set to `NA_real_` to enable default values selected by the algorithm.
@@ -22,6 +21,33 @@
 #' 
 #' @return A `gwrmultiscalem` object.
 #' 
+#' @details
+#' ## Configuration specification
+#' 
+#' In the multiscale GWR model,
+#' spatial weighting parameters can be specified for each parameter.
+#' There are several ways to make it easy and flexible.
+#' No matter in which way, the `config` parameter needs to be a list
+#' of `MGWRConfig` elements.
+#' 
+#' When the `config` list is not named, its length needs to be either 1
+#' or the number of independent variables (including the intercept if any).
+#' For the `config` of length 1,
+#' its only value will be applied for every independent variable.
+#' For the `config` that as long as independent variables,
+#' its values are mapped to variables by position.
+#' In other cases, an error will occur to prevent further process.
+#' 
+#' When the `config` list is named, the names can contain independent-variable names
+#' or a special character `".default"`.
+#' The function will look up config for each parameter according to its name
+#' in the `config` list.
+#' If `".default"` can be found in the list,
+#' once names of some parameters are missing in the `config`,
+#' the function will use the value of name `".default"` instead.
+#' However, if not all names can be found in `config` and the `".default"` name is missing,
+#' an error will occur to prevent further process.
+#' 
 #' @examples
 #' data(LondonHP)
 #' gwr_multiscale(
@@ -30,14 +56,15 @@
 #' )
 #'
 #' # Specify more configurations for all variables
-#' gwr_multiscale(
+#' m <- gwr_multiscale(
 #'  formula = PURCHASE ~ FLOORSZ + UNEMPLOY + PROF,
 #'  data = LondonHP,
 #'  config = list(mgwr_config(adaptive = TRUE, kernel = "bisquare"))
 #' )
+#' m
 #'
 #' # Specify more configurations for each variables
-#' m <- gwr_multiscale(
+#' gwr_multiscale(
 #'  formula = PURCHASE ~ FLOORSZ + UNEMPLOY + PROF,
 #'  data = LondonHP,
 #'  config = list(
@@ -46,7 +73,15 @@
 #'      mgwr_config(adaptive = TRUE, kernel = "bisquare"),
 #'      mgwr_config(adaptive = TRUE, kernel = "bisquare")
 #'  ))
-#' m
+#' 
+#' # Specify configurations by variable names
+#' gwr_multiscale(
+#'  formula = PURCHASE ~ FLOORSZ + UNEMPLOY + PROF,
+#'  data = LondonHP,
+#'  config = list(
+#'      FLOORSZ = mgwr_config(bw = 20, adaptive = TRUE, kernel = "bisquare"),
+#'      .default = mgwr_config(adaptive = TRUE, kernel = "bisquare")
+#'  ))
 #'
 #' @importFrom methods validObject
 #' @importFrom stats na.action model.frame model.extract model.matrix terms

--- a/R/gwr_multiscale.R
+++ b/R/gwr_multiscale.R
@@ -101,10 +101,24 @@ gwr_multiscale <- function(
     if (has_intercept && indep_vars[1] != "Intercept") {
         stop("Please put Intercept to the first column.")
     }
-    if (length(config) == 1) {
-        config <- rep(config, times = ncol(x))
-    } else if (length(config) != ncol(x)) {
-        stop("The length of config mush be equal to the number of independent variables.")
+
+    ### Extract config
+    if (is.null(names(config))) {
+        #### When configs are not specified by names, deal with it in the old way
+        if (length(config) == 1) {
+            config <- rep(config, times = ncol(x))
+        } else if (length(config) != ncol(x)) {
+            stop("The length of config mush be equal to the number of independent variables.")
+        }
+    } else {
+        #### When configs are specified by names, match it with parameters
+        if (all(indep_vars %in% names(config))) {
+            config <- config[indep_vars]
+        } else if (".default" %in% names(config)) {
+            config <- ifelse(indep_vars %in% names(config), config[indep_vars], config[".default"])
+        } else {
+            stop("Either specific configs for all variables, or provide a default config naming '.default'!")
+        }
     }
     if (has_intercept) {
         config[[1]]@centered <- FALSE

--- a/man/gwr_multiscale.Rd
+++ b/man/gwr_multiscale.Rd
@@ -37,8 +37,7 @@ gwr_multiscale(
 
 \item{config}{Parameter-specified weighting configuration.
 It must be a list of \code{MGWRConfig} objects.
-Its length can be 1 or equal to the number of independent variables.
-When its length is 1, elements will be duplicated for independent variable.}
+Please find more details in the details section.}
 
 \item{criterion}{Convergence criterion of back-fitting algorithm.}
 
@@ -78,6 +77,34 @@ A \code{gwrmultiscalem} object.
 \description{
 Multiscale GWR
 }
+\details{
+\subsection{Configuration specification}{
+
+In the multiscale GWR model,
+spatial weighting parameters can be specified for each parameter.
+There are several ways to make it easy and flexible.
+No matter in which way, the \code{config} parameter needs to be a list
+of \code{MGWRConfig} elements.
+
+When the \code{config} list is not named, its length needs to be either 1
+or the number of independent variables (including the intercept if any).
+For the \code{config} of length 1,
+its only value will be applied for every independent variable.
+For the \code{config} that as long as independent variables,
+its values are mapped to variables by position.
+In other cases, an error will occur to prevent further process.
+
+When the \code{config} list is named, the names can contain independent-variable names
+or a special character \code{".default"}.
+The function will look up config for each parameter according to its name
+in the \code{config} list.
+If \code{".default"} can be found in the list,
+once names of some parameters are missing in the \code{config},
+the function will use the value of name \code{".default"} instead.
+However, if not all names can be found in \code{config} and the \code{".default"} name is missing,
+an error will occur to prevent further process.
+}
+}
 \section{Functions}{
 \itemize{
 \item \code{plot(gwrmultiscalem)}: Plot the result of basic GWR model.
@@ -97,14 +124,15 @@ gwr_multiscale(
 )
 
 # Specify more configurations for all variables
-gwr_multiscale(
+m <- gwr_multiscale(
  formula = PURCHASE ~ FLOORSZ + UNEMPLOY + PROF,
  data = LondonHP,
  config = list(mgwr_config(adaptive = TRUE, kernel = "bisquare"))
 )
+m
 
 # Specify more configurations for each variables
-m <- gwr_multiscale(
+gwr_multiscale(
  formula = PURCHASE ~ FLOORSZ + UNEMPLOY + PROF,
  data = LondonHP,
  config = list(
@@ -113,7 +141,15 @@ m <- gwr_multiscale(
      mgwr_config(adaptive = TRUE, kernel = "bisquare"),
      mgwr_config(adaptive = TRUE, kernel = "bisquare")
  ))
-m
+
+# Specify configurations by variable names
+gwr_multiscale(
+ formula = PURCHASE ~ FLOORSZ + UNEMPLOY + PROF,
+ data = LondonHP,
+ config = list(
+     FLOORSZ = mgwr_config(bw = 20, adaptive = TRUE, kernel = "bisquare"),
+     .default = mgwr_config(adaptive = TRUE, kernel = "bisquare")
+ ))
 
 plot(m)
 

--- a/tests/testthat/test-gwr_multiscale.R
+++ b/tests/testthat/test-gwr_multiscale.R
@@ -8,6 +8,43 @@ test_that("Multiscale GWR: works", {
   ))
 })
 
+test_that("Multiscale GWR: specific config by names", {
+  #### all by name
+  expect_no_error({
+    gwr_multiscale(
+      formula = PURCHASE ~ FLOORSZ + UNEMPLOY + PROF,
+      data = LondonHP,
+      config = list(
+        Intercept = mgwr_config(adaptive = TRUE),
+        FLOORSZ = mgwr_config(adaptive = TRUE),
+        UNEMPLOY = mgwr_config(adaptive = TRUE),
+        PROF = mgwr_config(adaptive = TRUE)
+      )
+    )
+  })
+  #### use default value
+  expect_no_error({
+    gwr_multiscale(
+      formula = PURCHASE ~ FLOORSZ + UNEMPLOY + PROF,
+      data = LondonHP,
+      config = list(
+        FLOORSZ = mgwr_config(bw = 30, optim_bw = "no", adaptive = TRUE),
+        .default = mgwr_config(adaptive = TRUE)
+      )
+    )
+  })
+  #### error when default is missing and config is missing
+  expect_error({
+    gwr_multiscale(
+      formula = PURCHASE ~ FLOORSZ + UNEMPLOY + PROF,
+      data = LondonHP,
+      config = list(
+        FLOORSZ = mgwr_config(bw = 30, optim_bw = "no", adaptive = TRUE)
+      )
+    )
+  }, "Either specific configs for all variables, or provide a default config naming '.default'!")
+})
+
 test_that("Multiscale GWR: verbose", {
   skip_on_ci()
   expect_no_error(gwr_multiscale(

--- a/vignettes/tutorial-02-gwr-multiscale.Rmd
+++ b/vignettes/tutorial-02-gwr-multiscale.Rmd
@@ -174,7 +174,7 @@ gwr_multiscale(
   formula = PURCHASE ~ FLOORSZ + UNEMPLOY + PROF,
   data = LondonHP,
   config = list(
-    FLOORSZ = mgwr_config(bw = 92, adaptive = TRUE, kernel = "bisquare"),
+    FLOORSZ = mgwr_config(bw = 19, adaptive = TRUE, kernel = "bisquare"),
     .default = mgwr_config(adaptive = TRUE, kernel = "bisquare")
   )
 )

--- a/vignettes/tutorial-02-gwr-multiscale.Rmd
+++ b/vignettes/tutorial-02-gwr-multiscale.Rmd
@@ -165,3 +165,20 @@ m3
 ```
 
 Then the functions `c()` `rep()` can be used to flexiably create such a list.
+
+Alternatively, you can use a named list to set parameter-specific configuration.
+The name `".default"` can be used to configure variables that are not explicitly specified.
+
+```{r, cache=T}
+gwr_multiscale(
+  formula = PURCHASE ~ FLOORSZ + UNEMPLOY + PROF,
+  data = LondonHP,
+  config = list(
+    FLOORSZ = mgwr_config(bw = 92, adaptive = TRUE, kernel = "bisquare"),
+    .default = mgwr_config(adaptive = TRUE, kernel = "bisquare")
+  )
+)
+```
+
+Note that if `".default"` is missing, all variables need to be assigned a configuration by names.
+In other words, all variables need to appear in the names of `config` object, including the intercept if exists.


### PR DESCRIPTION
Now `gwr_multiscale` supports the specification of spatial weighting configuration by variable names. Take the following code as an example.

```R
gwr_multiscale(
  formula = PURCHASE ~ FLOORSZ + UNEMPLOY + PROF,
  data = LondonHP,
  config = list(
    FLOORSZ = mgwr_config(bw = 30, optim_bw = "no", adaptive = TRUE),
    .default = mgwr_config(adaptive = TRUE)
  )
)
```